### PR TITLE
docs: update READMEs across packages and apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 This repository is a hub for my projects and things I do in my free time. You can use it at your own risk 😅
 
-This project uses `yarn workspaces`, `Lerna`, and `NX` + `NX Cloud`
+This project uses `yarn workspaces` and `Lerna`
 
 ## What can I find here?
 
@@ -68,21 +68,19 @@ Run
 yarn && yarn husky install
 ```
 
-Or running any command from the root folder using `NX`
+Or run a specific package script from the root using `yarn workspace`:
 
 ```bash
-yarn nx run @mordech/[project][:target][:configuration]
+yarn workspace <package-name> <script>
 ```
 
 e.g.
 
 ```bash
-yarn nx run @mordech/portfolio:start
+yarn workspace hct-color-picker dev
 ```
 
-or use other NX commands (e.g., `run-many`, `affected`). For more, read [NX documentation](https://nx.dev/reference/commands#nx-cli-commands).
-
-I recommend using the [NX plugin](https://nx.dev/core-features/integrate-with-editors) as well.
+or use Lerna to run scripts across packages (e.g., `run`, `run --scope`). For more, read the [Lerna documentation](https://lerna.js.org/docs/api-reference/commands).
 
 ## Contributing
 

--- a/apps/hct-color-picker/README.md
+++ b/apps/hct-color-picker/README.md
@@ -17,6 +17,8 @@ Select elements in the document and change their colors in real time.
 
 - Change the color of the selected element.
 
+- Control the alpha (opacity) of colors with the dedicated alpha slider.
+
 ## Installation
 
 1. Go to the [plugin page](https://www.figma.com/community/plugin/1227923985322908257/HCT-Color-Picker)
@@ -32,7 +34,7 @@ Please follow the [Conventional Commits](https://www.conventionalcommits.org/en/
 
 1. Clone the repo
 2. Run `yarn install`
-3. Run `yarn nx run @mordech/hct-color-picker:watch`
+3. Run `yarn workspace hct-color-picker watch`
 4. Open Figma and go to Plugins > Development > Import plugin from manifest
 5. Select the `manifest.json` file in the `/apps/hct-color-picker/dist/` folder
 6. The plugin should now be available in the Plugins menu
@@ -43,10 +45,20 @@ The plugin uses [my web component library](/packages/web-components/) to build t
 
 ## Build
 
-1. Run `yarn nx run @mordech/hct-color-picker:build` to build the plugin
-2. The plugin will be available in the `/apps/hct-color-picker/dist/` folder
+The build has two targets that run concurrently:
+
+- **UI** (`build:ui`) — Vite bundles the iframe UI from `ui-src/`
+- **Plugin** (`build:plugin`) — esbuild bundles the Figma sandbox code from `plugin-src/` to `dist/code.js`
+
+Run both together:
+
+```bash
+yarn workspace hct-color-picker build
+```
 
 ## Contribution guidelines
+
+Please follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard and open an issue before submitting large changes.
 
 ## License
 

--- a/apps/inbox-zero-cats-for-gmail/README.md
+++ b/apps/inbox-zero-cats-for-gmail/README.md
@@ -5,7 +5,12 @@
 
 Inbox Zero Cats is a web extension for Gmail that displays a cat image instead of the inbox count. The cat image is from [Unsplash](https://unsplash.com/).
 
-You can also add custom images and titles to the extension
+## Features
+
+- Displays a cat image when your inbox reaches zero.
+- Add custom photos via URL in the **Photos** tab of the options page.
+- Add custom titles and subtitles via the **Titles** tab.
+- Content packs let you switch between curated sets of images and titles.
 
 ## How to install
 
@@ -22,8 +27,8 @@ You can also add custom images and titles to the extension
 ## How to develop
 
 - Run `yarn install`
-- Run `yarn start`
-- The web extension will be built in the `dist` folder and will be rebuilt whenever you make changes to the source code
+- Run `yarn bundle` to do a one-time build into `dist/`
+- To watch for changes, run `yarn bundle` and use a file watcher (e.g. `nodemon`) manually, or load the `dist/` folder as an unpacked extension and re-run `yarn bundle` as needed
 
 ## How to contribute
 

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -1,6 +1,7 @@
 # Component library
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/61471929-230b-44ef-bfa3-672d2aa4de64/deploy-status)](https://app.netlify.com/sites/mordech-react-components/deploys)
+[![Storybook](https://img.shields.io/badge/Storybook-FF4785?logo=storybook&logoColor=white&style=flat)](https://mordech-react-components.netlify.app/)
 
 The component library I'm going to use in my projects.
 
@@ -17,7 +18,7 @@ yarn storybook
 ## Build Storybook
 
 ```bash
-yarn nx build-storybook
+yarn lerna run build-storybook --scope=@mordech/react-components
 ```
 
 ## Visual regression testing
@@ -26,7 +27,7 @@ I use [Loki](https://loki.js.org/) for visual regression tests.
 Before creating a pull request, please run visual tests on the project.
 
 ```bash
-yarn nx visual
+yarn lerna run visual --scope=@mordech/react-components
 ```
 
 and follow the steps required to pass.
@@ -36,5 +37,5 @@ If changes have been made to existing components, please approve them.
 After approving the changes, run the following:
 
 ```bash
-yarn loki approve
+yarn lerna run visual:approve --scope=@mordech/react-components
 ```

--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -2,8 +2,6 @@
 
 [![Published on npm](https://img.shields.io/npm/v/@mordech/tokens.svg?logo=npm)](https://www.npmjs.com/package/@mordech/tokens)
 
-> ⚠️ This is a work in progress. Please don't use this package until this message is removed.
-
 This is a library for sharing design tokens (colors, typography, breakpoints, etc.) between projects.
 
 ## Why?
@@ -52,7 +50,7 @@ import { colors } from '@mordech/tokens';
 #### Usage
 
 ```js
-const Component = () => <div style={{ backgroundColor: colors.primary }} />;
+const Component = () => <div style={{ backgroundColor: colors.primary.base }} />;
 ```
 
 ## License

--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -1,5 +1,8 @@
 # @mordech/web-components
 
+[![Published on npm](https://img.shields.io/npm/v/@mordech/web-components.svg?logo=npm)](https://www.npmjs.com/package/@mordech/web-components)
+[![Storybook](https://img.shields.io/badge/Storybook-FF4785?logo=storybook&logoColor=white&style=flat)](https://mordech-web-components.netlify.app/)
+
 [@mordech/web-components](https://www.npmjs.com/package/@mordech/web-components) is a collection of reusable web components.
 
 ## Install
@@ -14,10 +17,10 @@ All components have the prefix `mrd-`.
 
 ```js
 import { html, render } from 'lit';
-import '@mordech/web-components/mrd-component';
+import '@mordech/web-components/mrd-button';
 
 const root = document.querySelector('#root');
-render(html`<mrd-component>Hello world</mrd-component>`, root);
+render(html`<mrd-button>Click me</mrd-button>`, root);
 ```
 
 ## Roadmap
@@ -39,10 +42,12 @@ changes.
 
 | Component           | Alpha | Beta | Stable |
 | ------------------- | :---: | :--: | :----: |
-| Button              |  🟡   |  🔴  |   🔴   |
-| Paint Swatch        |  🟢   |  🔴  |   🔴   |
+| Button              |  🟢   |  🟢  |   🔴   |
+| Chip                |  🟡   |  🔴  |   🔴   |
+| Paint Swatch        |  🟢   |  🟢  |   🔴   |
 | Range               |  🟢   |  🟢  |   🔴   |
-| Toggle Theme Button |  🟢   |  🟡  |   🔴   |
+| Text Field          |  🟡   |  🔴  |   🔴   |
+| Toggle Theme Button |  🟢   |  🟢  |   🔴   |
 
 ## License
 


### PR DESCRIPTION
## Summary

- Remove NX references in favour of `yarn workspace` / `lerna` commands (root README + react-components)
- Add alpha slider feature and fix build/dev commands in hct-color-picker
- Add features section to inbox-zero-cats reflecting the tabs/content packs UI rewrite
- Add `mrd-chip` and `mrd-text-field` to web-components roadmap; promote older components to Beta
- Add npm and Storybook badges to web-components and react-components; fix usage example to use real `mrd-button`
- Remove WIP warning from tokens README; fix `colors.primary` → `colors.primary.base` example
- Expand hct-color-picker build section to describe both build targets (`build:ui` / `build:plugin`)

## Test plan

- [x] Verify all command snippets in the READMEs match current package scripts
- [x] Confirm links and badges resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)